### PR TITLE
fix(tsp): resolve use-after-free in candidate list cache

### DIFF
--- a/include/evolab/problems/tsp.hpp
+++ b/include/evolab/problems/tsp.hpp
@@ -298,23 +298,8 @@ class TSP {
 
 // Implementations for candidate list methods
 inline void TSP::create_candidate_list(int k) const {
-    k = canonicalize_k(k);
-    // Fast path: check if already exists to avoid expensive O(n²) work
-    {
-        std::shared_lock<std::shared_mutex> lock(candidate_lists_mutex_);
-        if (candidate_lists_.contains(k)) {
-            return;
-        }
-    }
-
-    // Create distance matrix outside lock to minimize contention
-    // This O(n²) allocation and copy operation should not block other threads
-    auto matrix_2d = get_distance_matrix_2d();
-
-    // Exclusive lock for writing. try_emplace handles race if another thread
-    // created the entry in the meantime (won't overwrite)
-    std::lock_guard<std::shared_mutex> lock(candidate_lists_mutex_);
-    candidate_lists_.try_emplace(k, matrix_2d, k);
+    // Delegate to get_candidate_list, which handles creation if not present.
+    (void)get_candidate_list(k);
 }
 
 inline const utils::CandidateList* TSP::get_candidate_list(int k) const {


### PR DESCRIPTION
## Summary
Fixes critical use-after-free vulnerability in TSP candidate list caching mechanism by replacing single `std::optional<CandidateList>` with `std::unordered_map<int, CandidateList>` to maintain separate cache entries per k value.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test updates
- [ ] 🔧 Build/CI updates

## Related Task
**Issue**: Closes #23
**Priority**: 🔴 CRITICAL
**Dependencies**: None

## Key Features/Changes
- Replace single optional cache with multi-key map-based cache
- Add `has_candidate_list(int k)` overload for k-specific queries
- Add pointer stability test assertions
- Prevent use-after-free vulnerabilities when using multiple k values

## Technical Implementation

### Root Cause
The previous implementation used `std::optional<utils::CandidateList> candidate_list_` which reused the same memory location when `get_candidate_list(k)` was called with different k values. This invalidated all previously returned pointers, causing use-after-free bugs.

### Solution
```cpp
// Before: Single cache entry
mutable std::optional<utils::CandidateList> candidate_list_;

// After: Multi-key cache with pointer stability
mutable std::unordered_map<int, utils::CandidateList> candidate_lists_;
```

### Pointer Stability Guarantee
`std::unordered_map` guarantees that pointers/references to elements remain valid until that specific element is erased. Rehashing does not invalidate pointers (only iterators), ensuring safe concurrent access to different k-value caches.

### API Updates
- `has_candidate_list()` - checks if any candidate lists exist
- `has_candidate_list(int k)` - checks if list exists for specific k value
- `get_candidate_list(int k)` - returns stable pointer to cached list

## Performance Impact
- **Memory**: Slightly increased when multiple k values are used (expected behavior)
- **Speed**: No performance degradation; `unordered_map` provides O(1) average lookup
- **Cache efficiency**: Improved - no unnecessary recomputation when switching between k values

## Files Changed
- `include/evolab/problems/tsp.hpp` - Cache implementation fix
  - Add `<unordered_map>` header
  - Replace `candidate_list_` with `candidate_lists_` map
  - Update `create_candidate_list()` to use `try_emplace()`
  - Update `get_candidate_list()` to return stable map element pointer
  - Add `has_candidate_list(int k)` overload
- `tests/test_candidate_list.cpp` - Test coverage enhancement
  - Add assertions verifying pointer inequality for different k values
  - Add assertions verifying pointer stability after cache updates
  - Update comments to focus on safety requirements

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Performance benchmarks run

### Test Results
```
Test: TSP Integration
[PASS] Different k values should return different pointers
[PASS] Original pointer should still be valid (expected: 5, actual: 5)
[PASS] Original pointer should reference unchanged data (expected: 10, actual: 10)

=== Test Summary ===
Passed: 121/121 (TSP Integration)
Passed: 270/270 (All Candidate List Tests)

All test suites: 11/11 PASS
```

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The API is backward compatible. Existing code calling `get_candidate_list(k)` will continue to work identically, but now with guaranteed memory safety.

## Documentation
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated if needed
- [ ] Examples updated if needed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Code compiles without warnings
- [x] All tests pass
- [x] Comments added for complex logic
- [x] No sensitive information exposed
- [x] Performance impact considered
- [x] Error handling implemented where appropriate

## Additional Notes
This was a critical memory safety issue that could cause silent data corruption or crashes in production. The fix maintains the same API surface while providing stronger safety guarantees through proper cache separation and pointer stability.

The test suite now includes explicit verification of:
1. Pointer inequality for different k values
2. Pointer validity after subsequent cache operations
3. Data integrity after cache updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-k caching for candidate lists and an API to check availability for a specific k.

- Performance
  - Reduced lock contention and faster repeated lookups via concurrent read access.

- Bug Fixes
  - Ensures distinct cache entries per k and stabilizes previously created candidate list handles.

- Tests
  - Updated tests to verify separate per-k caches and stability of existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->